### PR TITLE
Shorten default nick length

### DIFF
--- a/scratch/irc-bot/irc_auth
+++ b/scratch/irc-bot/irc_auth
@@ -1,5 +1,5 @@
 {
-	"nickname":"conifers-irc-bot",
+	"nickname":"coniferbot",
 	"channels":[
 	],
 	"server":""


### PR DESCRIPTION
Many IRC servers limit nick length to 16 characters